### PR TITLE
Add GTM events for successful and failed vote submissions

### DIFF
--- a/src/components/Proposals/ProposalMain.tsx
+++ b/src/components/Proposals/ProposalMain.tsx
@@ -326,8 +326,21 @@ function ProposalMain({ props }: { props: Props }) {
             account: walletAddress,
           });
           StoreData(voteData);
+          pushToGTM({
+            event: "vote_submitted",
+            category: "Proposal Voting",
+            action: "Vote Submitted",
+            label: `Vote Submitted - Chain: ${currentChain}`,
+          });
+
         } catch (e) {
           toast.error("Transaction failed");
+          pushToGTM({
+            event: "vote_submission_failed",
+            category: "Proposal Voting",
+            action: "Vote Submission Failed",
+            label: `Vote Submission Failed - Chain: ${currentChain}`,
+          });
         }
       }
     } else if (!comment) {
@@ -345,8 +358,21 @@ function ProposalMain({ props }: { props: Props }) {
             account: walletAddress,
           });
           StoreData(voteData);
+          pushToGTM({
+            event: "vote_submitted",
+            category: "Proposal Voting",
+            action: "Vote Submitted",
+            label: `Vote Submitted - Chain: ${currentChain}`,
+          });
+
         } catch (e) {
           toast.error("Transaction failed");
+          pushToGTM({
+            event: "vote_submission_failed",
+            category: "Proposal Voting",
+            action: "Vote Submission Failed",
+            label: `Vote Submission Failed - Chain: ${currentChain}`,
+          });
         }
       }
     }
@@ -1075,7 +1101,7 @@ function ProposalMain({ props }: { props: Props }) {
             >
               Vote onchain
             </button>
-          )}
+          )} 
           <div className="flex-shrink-0">
             <div
               className={`rounded-full flex items-center justify-center text-xs py-1 px-2 font-medium ${


### PR DESCRIPTION
This pull request introduces Google Tag Manager (GTM) events to track the success or failure of on-chain vote submissions. These events provide valuable insights into user interactions during the voting process.

**Key Changes:**

-   Added `vote_submitted` GTM event:
    -   **Description:** This event is triggered when a vote submission is successful, and the label indicates the chain on which the vote was submitted.
-   Added `vote_submission_failed` GTM event:
    -   **Description:** This event is triggered when a vote submission fails, and the label indicates the chain where the failed vote occurred.

**Purpose:**

These GTM events will enable us to track:
  - The number of successful on-chain votes
  -  The number of unsuccessful on-chain votes.
  - Identify on which chain user are more active.
  - Debugging and improving the user experience related to voting.
