### PR TITLE
Correct Component Name

### DIFF
--- a/src/app/(routes)/explore-daos/page.tsx
+++ b/src/app/(routes)/explore-daos/page.tsx
@@ -3,7 +3,7 @@ import ConnectYourWallet from "@/components/ComponentUtils/ConnectYourWallet";
 import ExploreDAOs from "@/components/DAOs/ExploreDAOs";
 import { useAccount } from "wagmi";
 
-function page() {
+function Page() {
   const { isConnected } = useAccount();
     return (
       <>
@@ -17,4 +17,4 @@ function page() {
     );
   }
   
-  export default page;
+  export default Page;


### PR DESCRIPTION
**Changes Made:**

*   Updated the component name in `explore-dao/page.tsx` to start with a capital letter.

**Why This Change Was Necessary:**

*   React components should be named using PascalCase (capitalized first letter for each word).  Using lowercase names can lead to confusion and potential conflicts with HTML element names.
*   This change ensures consistency and maintainability of the codebase.